### PR TITLE
Resolve Placeholder Text Issue and Implement Drawing Mode for Note Area

### DIFF
--- a/scripts/jotpad.js
+++ b/scripts/jotpad.js
@@ -1,6 +1,6 @@
 // JotPad (JavaScript)
 
-ocument.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', function () {
   const noteArea = document.getElementById('noteArea')
   noteArea.innerHTML = localStorage.getItem('noteContent') || ''
 


### PR DESCRIPTION

### **Summary:**
- Fixed an issue where the **placeholder text** (`"Start typing here..."`) didn't disappear after typing.
- The problem was caused by a **spelling error** that prevented the script from running.
- - This improvement was made as part of the **OSconnect** open-source event, which I participated in.

---

### **Changes:**
1. **Spelling Error Fix**: Corrected a typo in the JavaScript, allowing the script to run and toggle the `empty` class correctly.
2. **Placeholder Behavior**: Once the script ran, the placeholder text now disappears as expected when the user starts typing.

---

### **Why It Was Happening:**
- The script was not executing because of a **spelling error** in the JavaScript file, which prevented the placeholder behavior logic from working correctly.

---


<img width="1920" height="985" alt="ResolvedStartTypingHere" src="https://github.com/user-attachments/assets/82cf1328-4041-4ef4-9e9a-bdadf1f15206" />


Closes #717